### PR TITLE
Fix multitenancy call

### DIFF
--- a/doc_source/es-kibana.md
+++ b/doc_source/es-kibana.md
@@ -95,7 +95,7 @@ server {
 
         # Update cookie domain and path
         proxy_cookie_domain $kibana_host $host;
-        proxy_cookie_path / /_plugin/kibana/;
+        proxy_cookie_path ~^/$ /_plugin/kibana/;
 
         # Response buffer settings
         proxy_buffer_size 128k;


### PR DESCRIPTION
Fix /_plugin/kibana/api/v1/multitenancy/tenant call, the security_authentification cookie already use the path /_plugin/kibana/ so it gets rewritten /_plugin/kibana/_plugin/kibana/ and this call would fail.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
