### PR TITLE
Adds PutLogEventsBatch perm to ES Logging policy

### DIFF
--- a/doc_source/audit-logs.md
+++ b/doc_source/audit-logs.md
@@ -41,6 +41,7 @@ If you encounter an error while following these steps, see [Can't enable audit l
          },
          "Action": [
            "logs:PutLogEvents",
+           "logs:PutLogEventsBatch",
            "logs:CreateLogStream"
          ],
          "Resource": "cw_log_group_arn"

--- a/doc_source/createdomain-configure-slow-logs.md
+++ b/doc_source/createdomain-configure-slow-logs.md
@@ -57,6 +57,7 @@ If you plan to enable multiple logs, we recommend publishing each to its own log
          },
          "Action": [
            "logs:PutLogEvents",
+           "logs:PutLogEventsBatch",
            "logs:CreateLogStream"
          ],
          "Resource": "cw_log_group_arn:*"
@@ -107,7 +108,7 @@ Now you can give OpenSearch Service permissions to write to the log group\. You 
 ```
 aws logs put-resource-policy \
   --policy-name my-policy \
-  --policy-document '{ "Version": "2012-10-17", "Statement": [{ "Sid": "", "Effect": "Allow", "Principal": { "Service": "es.amazonaws.com"}, "Action":[ "logs:PutLogEvents","logs:CreateLogStream"],"Resource": "cw_log_group_arn:*"}]}'
+  --policy-document '{ "Version": "2012-10-17", "Statement": [{ "Sid": "", "Effect": "Allow", "Principal": { "Service": "es.amazonaws.com"}, "Action":[ "logs:PutLogEvents", "logs:PutLogEventsBatch","logs:CreateLogStream"],"Resource": "cw_log_group_arn:*"}]}'
 ```
 
 **Important**  
@@ -181,7 +182,7 @@ Resources:
    Type: AWS::Logs::ResourcePolicy
    Properties:
      PolicyName: my-policy
-     PolicyDocument: "{ \"Version\": \"2012-10-17\", \"Statement\": [{ \"Sid\": \"\", \"Effect\": \"Allow\", \"Principal\": { \"Service\": \"es.amazonaws.com\"}, \"Action\":[ \"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\": \"arn:aws:logs:us-east-1:123456789012:log-group:opensearch-logs:*\"}]}"
+     PolicyDocument: "{ \"Version\": \"2012-10-17\", \"Statement\": [{ \"Sid\": \"\", \"Effect\": \"Allow\", \"Principal\": { \"Service\": \"es.amazonaws.com\"}, \"Action\":[ \"logs:PutLogEvents\",\"logs:PutLogEventsBatch\",\"logs:CreateLogStream\"],\"Resource\": \"arn:aws:logs:us-east-1:123456789012:log-group:opensearch-logs:*\"}]}"
 ```
 
 Finally, create the following CloudFormation stack which generates an OpenSearch Service domain with log publishing enabled\. The access policy permits the root user for the AWS account to make all HTTP requests to the domain:


### PR DESCRIPTION
The ElasticSearch logging requires `logs:PutLogEventsBatch` permission

*Description of changes:*

When attempting to configure Elastic Search logging to Cloudwatch logs without the `logs:PutLogEventsBatch` permission, we receive:

```
╷
│ Error: ValidationException: The Resource Access Policy specified for the CloudWatch Logs log group /aws/aes/domains/es-upgrade-staging/search-logs does not grant sufficient permissions for Amazon OpenSearch Service to create a log stream. Please check the Resource Access Policy.
│
│   with module.aws.module.elasticsearch.module.staging_upgrade.aws_elasticsearch_domain.this,
│   on ../../../modules/aws-elasticsearch/main.tf line 193, in resource "aws_elasticsearch_domain" "this":
│  193: resource "aws_elasticsearch_domain" "this" {
│
╵
```

Afterr adding the `logs:PutLogEventsBatch`, we were able to configure the logging on the ElasticSearch instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Notes

* It seems the [terraform docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy#elasticsearch-log-publishing) knew to add `PutLogEventsBatch`, which is actually how I figured this out.