### PR TITLE
Public endpoints are required for non-OpenSearch Service domains, too

### DIFF
--- a/doc_source/remote-reindex.md
+++ b/doc_source/remote-reindex.md
@@ -148,7 +148,7 @@ POST _reindex
 }
 ```
 
-In this case, only basic authorization with a username and password is supported\. The source domain must have a certificate signed by a public CA\. Self\-signed or private CA\-signed certificates are not supported\.
+In this case, only basic authorization with a username and password is supported\. The source domain must have a publicly accessible endpoint (even if it is in the same VPC as the target OpenSearch Service domain) and a certificate signed by a public CA\. Self\-signed or private CA\-signed certificates are not supported\.
 
 ## Reindex large datasets<a name="remote-reindex-largedatasets"></a>
 


### PR DESCRIPTION
*Issue #, if available:* (none)

*Description of changes:* The requirement for publicly accessible endpoints is already documented for reindexing between OpenSearch Service domains (in the two sections above the one changed here already), but is also required even when the source domain is self-managed and in the same VPC as the target OpenSearch Service domain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
