### PR TITLE
Update AmazonOpenSearchServiceSample.java

### DIFF
--- a/doc_source/serverless-clients.md
+++ b/doc_source/serverless-clients.md
@@ -316,7 +316,7 @@ public class AmazonOpenSearchServiceSample {
         // Index a document
         entity = new NStringEntity(sampleDocument, ContentType.APPLICATION_JSON);
         String id = "1";
-        request = new Request("POST", indexingPath + "/" + id);
+        request = new Request("POST", indexingPath);
         request.setEntity(entity);
 
         // Using a string instead of an HttpEntity sets Content-Type to application/json automatically.

--- a/sample_code/AmazonOpenSearchJavaClient-main/src/main/java/AmazonOpenSearchServiceSample.java
+++ b/sample_code/AmazonOpenSearchJavaClient-main/src/main/java/AmazonOpenSearchServiceSample.java
@@ -43,7 +43,7 @@ public class AmazonOpenSearchServiceSample {
         // Index a document
         entity = new NStringEntity(sampleDocument, ContentType.APPLICATION_JSON);
         String id = "1";
-        request = new Request("POST", indexingPath + "/" + id);
+        request = new Request("POST", indexingPath);
         request.setEntity(entity);
 
         // Using a String instead of an HttpEntity sets Content-Type to application/json automatically.


### PR DESCRIPTION
According to docs the following are supported:
1. POST <index>/_create/<id> (for search collection types only) 2 POST <index>/_doc

POST <index>/_doc/<id> is not supported. 
I have removed the id from the path, in order to work for both Search and Timeseries use case

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
