### PR TITLE
Fix Serverless JavaScript example

### DIFF
--- a/doc_source/serverless-clients.md
+++ b/doc_source/serverless-clients.md
@@ -234,7 +234,7 @@ var client = new Client({
       request = aws4.sign(request, AWS.config.credentials);
 
       // Add the body back into the request now the signature has been calculated without it
-      signedRequest.body = body;
+      request.body = body;
 
       return request
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The OpenSearch Serverless Service ignores the body and doesn't want it signed - need to sign without the body before adding the body back into the request. This was discussed in issue https://github.com/mhart/aws4/issues/37 and https://dev.to/makit/building-with-aws-opensearch-serverless-2moh where it was seen that using the given example would fail with signature problems because the server is calculating the signature without the body, but this example signs including the body.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
