### PR TITLE
Ensure .opendistro-reports-* are excluded from snapshot restore

### DIFF
--- a/doc_source/managedomains-snapshots.md
+++ b/doc_source/managedomains-snapshots.md
@@ -170,7 +170,7 @@ print(r.text)
 # url = host + path
 #
 # payload = {
-#   "indices": "-.kibana*,-.opendistro_security",
+#   "indices": "-.kibana*,-.opendistro_security,-.opendistro-*",
 #   "include_global_state": False
 # }
 #


### PR DESCRIPTION
_Issue #, if available:_
None

_Description of changes:_
Currently, snapshot restore code payload leads to 403 response.

There are two more indices, that needs to be excluded to avoid this error:
- .opendistro-reports-definitions
- .opendistro-reports-instances


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

