### PR TITLE
Missing documentation when use Amplify

### DIFF
--- a/doc_source/supported-instance-types.md
+++ b/doc_source/supported-instance-types.md
@@ -38,3 +38,6 @@ OpenSearch Service offers previous generation instance types for users who have 
 
 **Tip**  
 We often recommend different instance types for [dedicated master nodes](managedomains-dedicatedmasternodes.md) and data nodes\.
+
+**Notes**
+If you are using [OpenSearch in a Amplify Project](https://docs.amplify.aws/cli/graphql/search-and-result-aggregations/#set-up-opensearch-for-production-environments) you should replace `.search` to `.elasticsearch`


### PR DESCRIPTION
*Issue:*

Currently the documentation not said what are the correct values to use the attribute `OpenSearchInstanceType` when you are using Amplify with OpenSearch

*Description of changes:*

When you use some values from this document and you want deploy a new version of your project with Amplify, I got this error

```
UPDATE_FAILED               OpenSearchDomain                                                                                    AWS::Elasticsearch::Domain Mon Apr 03 2023 21:11:40 GMT+0000 (Coordinated Universal Time) 
1 validation error detected: Value 't3.small.search' at 'elasticsearchClusterConfig.instanceType' failed to satisfy constraint: Member must satisfy enum value set: [m6i.xlarge.elasticsearch, r6i.16xlarge.elasticsearch, r6gd.12xlarge.elasticsearch, i3.2xlarge.elasticsearch, ultrawarm1.xlarge.elasticsearch, m5.4xlarge.elasticsearch, i4i.32xlarge.elasticsearch, m6i.12xlarge.elasticsearch, r6i.8xlarge.elasticsearch, r6i.large.elasticsearch, t3.xlarge.elasticsearch, i4i.xlarge.elasticsearch, r6a.32xlarge.elasticsearch, m6g.xlarge.elasticsearch, i3.4xlarge.elasticsearch, m3.large.elasticsearch, r6a.xlarge.elasticsearch, m7g.xlarge.elasticsearch, m6g.12xlarge.elasticsearch, r7g.16xlarge.elasticsearch, r4.16xlarge.elasticsearch, t2.micro.elasticsearch, m4.large.elasticsearch, r6a.12xlarge.elasticsearch, c6a.2xlarge.elasticsearch, m6i.48xlarge.elasticsearch, r6gd.16xlarge.elasticsearch, m7g.12xlarge.elasticsearch, d2.2xlarge.elasticsearch, t3.micro.elasticsearch, m5.8xlarge.elasticsearch, m5.large.elasticsearch, r6a.24xlarge.elasticsearch, m6i.16xlarge.elasticsearch, c6a.4xlarge.elasticsearch, i3.8xlarge.elasticsearch, i3.large.elasticsearch, d2.4xlarge.elasticsearch, t2.small.elasticsearch, i4i.16xlarge.elasticsearch, m6a.32xlarge.elasticsearch, c4.2xlarge.elasticsearch, t3.small.elasticsearch, m6a.xlarge.elasticsearch, r6a.16xlarge.elasticsearch, m7g.16xlarge.elasticsearch, c5.2xlarge.elasticsearch, im4gn.xlarge.elasticsearch, t4i.medium.elasticsearch, m6a.12xlarge.elasticsearch, c6i.32xlarge.elasticsearch, c7g.2xlarge.elasticsearch, c4.4xlarge.elasticsearch, c6a.8xlarge.elasticsearch, c6a.large.elasticsearch, c6i.xlarge.elasticsearch, c6g.2xlarge.elasticsearch, d2.8xlarge.elasticsearch, c5.4xlarge.elasticsearch, c6i.12xlarge.elasticsearch, t4g.medium.elasticsearch, c7g.4xlarge.elasticsearch, m6a.48xlarge.elasticsearch, c6i.24xlarge.elasticsearch, c6i.2xlarge.elasticsearch, c6g.4xlarge.elasticsearch, c6g.xlarge.elasticsearch, m3.medium.elasticsearch, im4gn.2xlarge.elasticsearch, m6a.16xlarge.elasticsearch, c7g.xlarge.elasticsearch, c6g.12xlarge.elasticsearch, c4.8xlarge.elasticsearch, c4.large.elasticsearch, im4gn.16xlarge.elasticsearch, m6a.2xlarge.elasticsearch, c6i.4xlarge.elasticsearch, c7g.12xlarge.elasticsearch, c5.xlarge.elasticsearch, c5.large.elasticsearch, im4gn.4xlarge.elasticsearch, c6i.16xlarge.elasticsearch, t4g.small.elasticsearch, c7g.8xlarge.elasticsearch, c7g.large.elasticsearch, r6g.medium.elasticsearch, c4.xlarge.elasticsearch, c5.9xlarge.elasticsearch, m6a.4xlarge.elasticsearch, c6g.8xlarge.elasticsearch, c6g.large.elasticsearch, c6a.32xlarge.elasticsearch, c6a.xlarge.elasticsearch, c6i.8xlarge.elasticsearch, c6i.large.elasticsearch, c7g.16xlarge.elasticsearch, d2.xlarge.elasticsearch, ultrawarm1.medium.elasticsearch, t3.nano.elasticsearch, im4gn.8xlarge.elasticsearch, im4gn.large.elasticsearch, r6a.2xlarge.elasticsearch, c6a.12xlarge.elasticsearch, m7g.2xlarge.elasticsearch, t3.medium.elasticsearch, i4i.2xlarge.elasticsearch, m6a.8xlarge.elasticsearch, m6a.large.elasticsearch, m6g.2xlarge.elasticsearch, m6g.medium.elasticsearch, t2.medium.elasticsearch, r6a.4xlarge.elasticsearch, m7g.4xlarge.elasticsearch, t3.2xlarge.elasticsearch, c5.18xlarge.elasticsearch, i4i.4xlarge.elasticsearch, c6a.48xlarge.elasticsearch, m6i.2xlarge.elasticsearch, m6g.4xlarge.elasticsearch, i3.xlarge.elasticsearch, c6a.16xlarge.elasticsearch, r6gd.2xlarge.elasticsearch, i2.xlarge.elasticsearch, r3.2xlarge.elasticsearch, m6i.4xlarge.elasticsearch, r7g.2xlarge.elasticsearch, r4.2xlarge.elasticsearch, m5.xlarge.elasticsearch, m4.10xlarge.elasticsearch, r6a.8xlarge.elasticsearch, r6a.large.elasticsearch, r6gd.4xlarge.elasticsearch, m7g.8xlarge.elasticsearch, m7g.large.elasticsearch, r6g.2xlarge.elasticsearch, r3.4xlarge.elasticsearch, r5.2xlarge.elasticsearch, m5.12xlarge.elasticsearch, m4.xlarge.elasticsearch, i4i.8xlarge.elasticsearch, i4i.large.elasticsearch, r6i.32xlarge.elasticsearch, m6g.8xlarge.elasticsearch, m6g.large.elasticsearch, r7g.4xlarge.elasticsearch, r4.4xlarge.elasticsearch, m5.24xlarge.elasticsearch, m3.xlarge.elasti
```

Currently the [documentation of Amplify](https://docs.amplify.aws/cli/graphql/search-and-result-aggregations/#set-up-opensearch-for-production-environments) have a link to this document to see all types of instance:

![image](https://user-images.githubusercontent.com/47902534/229631039-011cb7df-41bd-4e55-8fb6-4c1bc3b471a0.png)

