### PR TITLE
update hosts to work in latest version of client

### DIFF
--- a/doc_source/request-signing.md
+++ b/doc_source/request-signing.md
@@ -94,6 +94,7 @@ from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
 import boto3
 
 host = '' # cluster endpoint, for example: my-test-domain.us-east-1.es.amazonaws.com
+port = 443
 region = '' # e.g. us-west-1
 
 credentials = boto3.Session().get_credentials()
@@ -101,7 +102,7 @@ auth = AWSV4SignerAuth(credentials, region)
 index_name = 'movies'
 
 client = OpenSearch(
-    hosts = [{'host': host, 'port': 443}],
+    hosts = [f'{host}:{port}'],
     http_auth = auth,
     use_ssl = True,
     verify_certs = True,


### PR DESCRIPTION
*Description of changes:*

the syntax used in the docs throws an error on the latest version of the opensearch-py client.

```
requests.exceptions.InvalidURL: Failed to parse: https://[https://DOMAIN_ENDPOINT.REGION.es.amazonaws.com]:443/
```
(actual values for endpoint and region above redacted)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
