### PR TITLE
Fix sample Java code to connect to opensearch serverless collection

### DIFF
--- a/doc_source/serverless-clients.md
+++ b/doc_source/serverless-clients.md
@@ -238,6 +238,10 @@ The following sample code uses the [opensearch\-java](https://search.maven.org/a
 The important difference compared to OpenSearch Service *domains* is the service name \(`aoss` instead of `es`\)\.
 
 ```
+// import OpenSearchClient to establish connection to OpenSearch Serverless collection
+import org.opensearch.client.opensearch.OpenSearchClient;
+
+
 SdkHttpClient httpClient = ApacheHttpClient.builder().build();
 
 // create an opensearch client and use the request-signer
@@ -259,7 +263,7 @@ CreateIndexResponse createIndexResponse = client.indices().create(createIndexReq
 System.out.println("Create index reponse: " + createIndexResponse);
 
 // delete the index
-DeleteIndexRequest deleteIndexRequest = new DeleteRequest.Builder().index(index).build();
+DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest.Builder().index(index).build();
 DeleteIndexResponse deleteIndexResponse = client.indices().delete(deleteIndexRequest);
 System.out.println("Delete index reponse: " + deleteIndexResponse);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add import to better help users distinguish which OpenSearchClient to import
Users might import https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/opensearch/OpenSearchClient.html which is used to manage Amazon managed Opensearch service domains. This client cannot be used to connect to an Opensearch serverless collection.


2. Correct DeleteIndexRequest statement.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
