### PR TITLE
add prerequisite when using vpc conenction

### DIFF
--- a/doc_source/remote-reindex.md
+++ b/doc_source/remote-reindex.md
@@ -22,6 +22,8 @@ Remote reindex has the following requirements:
 + The remote domain must be accessible from the local domain\. For a remote domain that resides within a VPC, the local domain must have access to the VPC\. This process varies by network configuration, but likely involves connecting to a VPN or managed network, or using the native [VPC endpoint connection](#remote-reindex-vpc)\. To learn more, see [Launching your Amazon OpenSearch Service domains within a VPC](vpc.md)\. 
 + The request must be authorized by the remote domain like any other REST request\. If the remote domain has fine\-grained access control enabled, you must have permission to perform reindex on the remote domain and read the index on the local domain\. For more security considerations, see [Fine\-grained access control in Amazon OpenSearch Service](fgac.md)\.
 + We recommend you create an index with the desired setting on your local domain before you start the reindex process\.
++ When the remote is in a VPC, and you're using the built-in VPC endpoint connection, the local domain should be an OpenSearch domain with the latest service software versions. The remote domain can be on OpenSearch/Elasticsearch version, however, it has to be on the latest service software version.
+
 
 ## Reindex data between OpenSearch Service internet domains<a name="remote-reindex-domain"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

as the reply from service team, the local domain should be an Opensearch domain when using built-in VPC endpoint connection for remote-reindexing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
